### PR TITLE
add domain/kind listing and local skill file path output (remade

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ langskills-rai bundle-install --auto
 
 ```bash
 langskills-rai skill-search "<query>" [options]
+langskills-rai skill-search --domains
+langskills-rai skill-search --kinds
 ```
 
 ### Parameters
@@ -355,7 +357,10 @@ langskills-rai skill-search "<query>" [options]
 | Flag | Description | Default |
 |:---|:---|:---|
 | `--top N` | Number of results | 5 |
+| `--domains` | List available domains and exit | off |
+| `--kinds` | List available skill kinds and exit | off |
 | `--domain <d>` | Filter by domain | all |
+| `--show-path` | Show local `skill.md` path for each result | off |
 | `--min-score N` | Minimum quality score (0-5) | 0 |
 | `--content` | Include full skill body | off |
 | `--format markdown` | Output as Markdown | text |
@@ -364,6 +369,7 @@ langskills-rai skill-search "<query>" [options]
 
 ```bash
 langskills-rai skill-search "CRISPR gene editing" --domain research --top 3 --content --format markdown
+langskills-rai skill-search "kubernetes networking" --top 5 --show-path
 ```
 
 ## Reading Results

--- a/core/cli.py
+++ b/core/cli.py
@@ -94,6 +94,7 @@ def main(argv: list[str] | None = None) -> int:
     p_ss.add_argument("--min-score", type=float, default=0.0, help="Minimum overall_score")
     p_ss.add_argument("--domains", action="store_true", help="List available domains and exit")
     p_ss.add_argument("--kinds", action="store_true", help="List available skill kinds and exit")
+    p_ss.add_argument("--show-path", action="store_true", help="Show local skill.md paths in results")
     p_ss.add_argument("--content", action="store_true", help="Include full skill.md content")
     p_ss.add_argument("--max-chars", type=int, default=4000, help="Truncate skill content (0=unlimited)")
     p_ss.add_argument("--format", choices=["brief", "markdown", "json"], default="brief", help="Output format")
@@ -1270,6 +1271,8 @@ def main(argv: list[str] | None = None) -> int:
             raw_args.append("--domains")
         if ns.kinds:
             raw_args.append("--kinds")
+        if ns.show_path:
+            raw_args.append("--show-path")
         if ns.domain:
             raw_args += ["--domain", ns.domain]
         if ns.kind:

--- a/core/cli.py
+++ b/core/cli.py
@@ -92,6 +92,8 @@ def main(argv: list[str] | None = None) -> int:
     p_ss.add_argument("--kind", default="", help="Filter by skill_kind")
     p_ss.add_argument("--source-type", default="", help="Filter by source_type")
     p_ss.add_argument("--min-score", type=float, default=0.0, help="Minimum overall_score")
+    p_ss.add_argument("--domains", action="store_true", help="List available domains and exit")
+    p_ss.add_argument("--kinds", action="store_true", help="List available skill kinds and exit")
     p_ss.add_argument("--content", action="store_true", help="Include full skill.md content")
     p_ss.add_argument("--max-chars", type=int, default=4000, help="Truncate skill content (0=unlimited)")
     p_ss.add_argument("--format", choices=["brief", "markdown", "json"], default="brief", help="Output format")
@@ -1264,6 +1266,10 @@ def main(argv: list[str] | None = None) -> int:
 
         raw_args = [ns.query] if ns.query else []
         raw_args += ["--top", str(ns.top)]
+        if ns.domains:
+            raw_args.append("--domains")
+        if ns.kinds:
+            raw_args.append("--kinds")
         if ns.domain:
             raw_args += ["--domain", ns.domain]
         if ns.kind:

--- a/core/search.py
+++ b/core/search.py
@@ -460,6 +460,63 @@ def search_skills(
     return results
 
 
+def _list_distinct_values(column: str) -> list[str]:
+    """Return sorted unique values from ``skills_index.<column>``."""
+    values: set[str] = set()
+    bundles = _resolve_all_bundles()
+    if bundles:
+        for bp in bundles:
+            try:
+                conn = sqlite3.connect(f"file:{bp}?mode=ro", uri=True)
+                rows = conn.execute(
+                    f"SELECT DISTINCT {column} FROM skills_index "
+                    f"WHERE COALESCE({column}, '') != ''"
+                ).fetchall()
+                for row in rows:
+                    val = str(row[0] or "").strip()
+                    if val:
+                        values.add(val)
+            except Exception:
+                continue
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        return sorted(values)
+
+    idx_path = _index_db()
+    if not idx_path.exists():
+        raise FileNotFoundError(
+            f"No bundle found and index database missing: {idx_path}\n"
+            "Install a bundle with: langskills bundle-install"
+        )
+
+    conn = sqlite3.connect(f"file:{idx_path}?mode=ro", uri=True)
+    try:
+        rows = conn.execute(
+            f"SELECT DISTINCT {column} FROM skills_index "
+            f"WHERE COALESCE({column}, '') != ''"
+        ).fetchall()
+        for row in rows:
+            val = str(row[0] or "").strip()
+            if val:
+                values.add(val)
+    finally:
+        conn.close()
+    return sorted(values)
+
+
+def list_domains() -> list[str]:
+    """Return sorted unique domain values from installed bundles/index."""
+    return _list_distinct_values("domain")
+
+
+def list_kinds() -> list[str]:
+    """Return sorted unique skill_kind values from installed bundles/index."""
+    return _list_distinct_values("skill_kind")
+
+
 # ── formatters ───────────────────────────────────────────────────
 
 def format_brief(results: list[dict[str, Any]]) -> str:
@@ -525,8 +582,10 @@ def cli_skill_search(argv: list[str] | None = None) -> int:
         prog="langskills-rai skill-search",
         description="Search the LangSkills skill library",
     )
-    p.add_argument("query", help="Free-text search query")
+    p.add_argument("query", nargs="?", default="", help="Free-text search query")
     p.add_argument("--top", type=int, default=10, help="Max results (default: 10)")
+    p.add_argument("--domains", action="store_true", help="List available domains and exit")
+    p.add_argument("--kinds", action="store_true", help="List available skill kinds and exit")
     p.add_argument("--domain", default="", help="Filter by domain (linux, ml, web, ...)")
     p.add_argument("--kind", default="", help="Filter by skill_kind (github, arxiv, ...)")
     p.add_argument("--source-type", default="", help="Filter by source_type (github, journal, ...)")
@@ -544,6 +603,27 @@ def cli_skill_search(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
 
     fmt = "brief" if args.brief else args.format
+
+    if args.domains:
+        try:
+            domains = list_domains()
+        except FileNotFoundError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        print("\n".join(domains) if domains else "No domains found.")
+        return 0
+
+    if args.kinds:
+        try:
+            kinds = list_kinds()
+        except FileNotFoundError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        print("\n".join(kinds) if kinds else "No kinds found.")
+        return 0
+
+    if not str(args.query or "").strip():
+        p.error("query is required unless --domains or --kinds is set")
 
     try:
         results = search_skills(

--- a/core/search.py
+++ b/core/search.py
@@ -519,7 +519,20 @@ def list_kinds() -> list[str]:
 
 # ── formatters ───────────────────────────────────────────────────
 
-def format_brief(results: list[dict[str, Any]]) -> str:
+def _local_skill_md_path(item: dict[str, Any]) -> str:
+    """Best-effort local skill.md path from index metadata."""
+    raw_dir = str(item.get("dir") or "").strip()
+    if raw_dir:
+        base = raw_dir.replace("\\", "/").rstrip("/")
+    else:
+        skill_id = str(item.get("skill_id") or "").strip()
+        base = f"skills/by-skill/{skill_id}" if skill_id else ""
+    if not base:
+        return ""
+    return f"{base}/skill.md"
+
+
+def format_brief(results: list[dict[str, Any]], *, show_path: bool = False) -> str:
     """One line per result: score | domain | kind | title."""
     if not results:
         return "No results found."
@@ -529,11 +542,16 @@ def format_brief(results: list[dict[str, Any]]) -> str:
         domain = r.get("domain") or "-"
         kind = r.get("skill_kind") or "-"
         title = r.get("title") or "(untitled)"
-        lines.append(f"{i:>3}. [{score:.1f}] {domain:<14} {kind:<10} {title}")
+        line = f"{i:>3}. [{score:.1f}] {domain:<14} {kind:<10} {title}"
+        if show_path:
+            path = _local_skill_md_path(r)
+            if path:
+                line += f"\n     path: {path}"
+        lines.append(line)
     return "\n".join(lines)
 
 
-def format_markdown(results: list[dict[str, Any]]) -> str:
+def format_markdown(results: list[dict[str, Any]], *, show_path: bool = False) -> str:
     """Full Markdown output suitable for agent consumption."""
     if not results:
         return "No results found."
@@ -554,6 +572,10 @@ def format_markdown(results: list[dict[str, Any]]) -> str:
             f"- **Source type:** {source_type}\n"
             f"- **Skill ID:** `{skill_id[:12]}...`\n"
         )
+        if show_path:
+            path = _local_skill_md_path(r)
+            if path:
+                meta += f"- **Path:** `{path}`\n"
         body = ""
         if "skill_md" in r and r["skill_md"]:
             body = f"\n### Content\n\n{r['skill_md']}\n"
@@ -586,6 +608,7 @@ def cli_skill_search(argv: list[str] | None = None) -> int:
     p.add_argument("--top", type=int, default=10, help="Max results (default: 10)")
     p.add_argument("--domains", action="store_true", help="List available domains and exit")
     p.add_argument("--kinds", action="store_true", help="List available skill kinds and exit")
+    p.add_argument("--show-path", action="store_true", help="Show local skill.md paths in results")
     p.add_argument("--domain", default="", help="Filter by domain (linux, ml, web, ...)")
     p.add_argument("--kind", default="", help="Filter by skill_kind (github, arxiv, ...)")
     p.add_argument("--source-type", default="", help="Filter by source_type (github, journal, ...)")
@@ -641,9 +664,9 @@ def cli_skill_search(argv: list[str] | None = None) -> int:
         return 1
 
     if fmt == "brief":
-        print(format_brief(results))
+        print(format_brief(results, show_path=bool(args.show_path)))
     elif fmt == "markdown":
-        print(format_markdown(results))
+        print(format_markdown(results, show_path=bool(args.show_path)))
     else:
         print(format_json(results))
 


### PR DESCRIPTION
Adds small UX improvements to skill-search (motivated by my personal usage:

--domains: list available domains

--kinds: list available skill kinds

--show-path: show local skill.md path in text outputs (brief/markdown)

Also updates CLI behavior so query is only optional for --domains/--kinds, and updates README examples/flags accordingly.